### PR TITLE
Update mab.py

### DIFF
--- a/kaggle_environments/envs/mab/mab.py
+++ b/kaggle_environments/envs/mab/mab.py
@@ -127,8 +127,8 @@ def renderer(steps, env):
     board = ""
 
     for i in range(1, rounds_played):
-        actions = [agent.action for agent in steps[i]]
-        rewards = [agent.reward for agent in steps[i]]
+        actions = [agent.action for agent in env.steps[i]]
+        rewards = [agent.reward for agent in env.steps[i]]
         board += f"Round {i} Actions: {actions}, Rewards: {rewards}\n"
 
     return board


### PR DESCRIPTION
Fix for `str' object has no attribute 'action'`-error from issue #121.

It uses `env.steps` instead of `steps` which is `env.state`. This works but is probably not the best fix for this issue.